### PR TITLE
Property initializers happening after dictionary initializers that depend on them?

### DIFF
--- a/BoolExprNet.Tests/ExpressionTests.cs
+++ b/BoolExprNet.Tests/ExpressionTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static BoolExprNet.Expression;
 
@@ -20,6 +22,24 @@ namespace BoolExprNet.Tests
 
             var f = Equal(IfThenElse(Not(Or(And(a, b, Not(c)), And(a, Not(b), c), And(Not(a), b, c))), b, c), z).ToDnf().ToCnf().ToDnf().Simplify();
             var s = f.ToString();
+        }
+
+        [TestMethod]
+        public void Should_not_return_null_when_using_zero_literal()
+        {
+            using var ctx = new Context();
+            var v = Zero;
+            var f = Not(v);
+            f.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void Should_not_return_null_when_using_one_literal()
+        {
+            using var ctx = new Context();
+            var v = One;
+            var f = Not(v);
+            f.Should().NotBeNull();
         }
 
     }

--- a/BoolExprNet/Expression.cs
+++ b/BoolExprNet/Expression.cs
@@ -8,8 +8,23 @@ using BoolExprNet.Internal;
 namespace BoolExprNet
 {
 
+    /// <summary>
+    /// Base expression class.
+    /// </summary>
     public abstract class Expression : ManagedRef
     {
+
+        #region Known
+
+        public static ZeroLiteral Zero = new ZeroLiteral(Native.boolexpr_zero());
+
+        public static OneLiteral One = new OneLiteral(Native.boolexpr_one());
+
+        public static Logical Logical = new Logical(Native.boolexpr_logical());
+
+        public static Illogical Illogical = new Illogical(Native.boolexpr_illogical());
+
+        #endregion
 
         static readonly Dictionary<Kind, Expression> KIND2CONST = new Dictionary<Kind, Expression>()
         {
@@ -40,18 +55,6 @@ namespace BoolExprNet
             [Kind.NotIfThenElse] = cbx => new NotIfThenElse(cbx),
             [Kind.IfThenElse] = cbx => new IfThenElse(cbx),
         };
-
-        #region Known
-
-        public static ZeroLiteral Zero = new ZeroLiteral(Native.boolexpr_zero());
-
-        public static OneLiteral One = new OneLiteral(Native.boolexpr_one());
-
-        public static Logical Logical = new Logical(Native.boolexpr_logical());
-
-        public static Illogical Illogical = new Illogical(Native.boolexpr_illogical());
-
-        #endregion
 
         #region Operators
 


### PR DESCRIPTION
Kinda surprised this happens. Thought property initializers were sorted by their dependency. Guess not.